### PR TITLE
Added switch to enable "limiting" functionality rather than fixed volume

### DIFF
--- a/app/src/main/java/com/klee/volumelockr/BootReceiver.kt
+++ b/app/src/main/java/com/klee/volumelockr/BootReceiver.kt
@@ -10,12 +10,7 @@ class BootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == Intent.ACTION_BOOT_COMPLETED) {
-            val service = Intent(context, VolumeService::class.java)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(service)
-            } else {
-                context.startService(service)
-            }
+            VolumeService.start(context)
         }
     }
 }

--- a/app/src/main/java/com/klee/volumelockr/service/VolumeService.kt
+++ b/app/src/main/java/com/klee/volumelockr/service/VolumeService.kt
@@ -51,6 +51,15 @@ class VolumeService : Service() {
         const val VOLUME_VOICE_BT_SETTING = "volume_voice_bt_a2dp"
 
         const val MODE_RINGER_SETTING = "mode_ringer"
+
+        fun start(context: Context) {
+            val service = Intent(context, VolumeService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(service)
+            } else {
+                context.startService(service)
+            }
+        }
     }
 
     private lateinit var mAudioManager: AudioManager

--- a/app/src/main/java/com/klee/volumelockr/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/SettingsFragment.kt
@@ -2,6 +2,8 @@ package com.klee.volumelockr.ui
 
 import android.app.AlertDialog
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.text.InputType
 import android.view.View
@@ -12,12 +14,14 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
 import androidx.preference.SwitchPreferenceCompat
 import com.klee.volumelockr.R
+import com.klee.volumelockr.service.VolumeService
 
 class SettingsFragment : PreferenceFragmentCompat() {
 
     companion object {
         const val PASSWORD_PROTECTED_PREFERENCE = "password_protected"
         const val PASSWORD_CHANGE_PREFERENCE = "password"
+        const val ALLOW_LOWER = "allow_lower"
     }
 
     private lateinit var passwordProtected: SwitchPreferenceCompat
@@ -48,6 +52,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
         passwordProtected.isEnabled = isPasswordSet()
+
+        val allowLower : SwitchPreferenceCompat = findPreference(ALLOW_LOWER)!!
+        allowLower.setOnPreferenceChangeListener {preference, _ ->
+            // re-send start command to service to reload preference
+            VolumeService.start(preference.context)
+            true
+        }
     }
 
     private fun askForPassword() {

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
@@ -44,7 +44,7 @@ class VolumeAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val volume = mVolumeList[position]
         holder.binding.mediaTextView.text = volume.name
-        holder.binding.seekBar.progress = volume.value
+        holder.binding.seekBar.progress = mService?.getLocks()?.get(volume.stream) ?: volume.value
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             holder.binding.seekBar.min = volume.min
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,9 @@
     <string name="aboutLibraries_description_showVersion">true</string>
 
     <!-- Preferences -->
+    <string name="limiting_header">Volume Limiting</string>
+    <string name="allow_lower">Allow lower volume than limit</string>
+    <string name="allow_lower_message">Change will take effect when you restart your device</string>
     <string name="password_header">Password</string>
     <string name="password_protected">Enable password protection</string>
     <string name="change_password">Change password</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,14 +1,23 @@
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
+  <PreferenceCategory app:title="@string/limiting_header">
+
+    <SwitchPreferenceCompat
+        app:key="allow_lower"
+        app:title="@string/allow_lower"
+        app:defaultValue="false" />
+
+  </PreferenceCategory>
+
   <PreferenceCategory app:title="@string/password_header">
 
     <SwitchPreferenceCompat
-      app:key="password_protected"
-      app:title="@string/password_protected" />
+        app:key="password_protected"
+        app:title="@string/password_protected" />
 
     <EditTextPreference
-      app:key="password"
-      app:title="@string/change_password">
+        app:key="password"
+        app:title="@string/change_password">
 
     </EditTextPreference>
 


### PR DESCRIPTION
Added a switch in the preferences that sets the lock as a maximum limit, rather than a fixed value.

This involved:

- Adding a new root preference to default shared preferences
- Reading the preference when the VolumeService starts
- Sending an intent to the service when the preference changes
- Updating the GUI to show the lock value on the progress bars (when a lock is set) rather than the current stream value
- Moved creating the service intent from the BootReceiver to a static function in the VolumeService (to avoid duplicating the intent logic)
- Added 3 strings (in English--my French isn't great, so I'll let someone else do that)

Love the app, hope this helps.  Thanks for publishing it!