### PR TITLE
Add volume presets feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-android'
     id "androidx.navigation.safeargs.kotlin"
     id 'com.mikepenz.aboutlibraries.plugin'
+    id 'kotlin-parcelize'
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,8 @@
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.kapt' apply false
+    id 'org.jetbrains.kotlin.kapt'
     id 'kotlin-android'
+    id "androidx.navigation.safeargs.kotlin"
     id 'com.mikepenz.aboutlibraries.plugin'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.kapt'
+    id 'org.jetbrains.kotlin.kapt' apply false
     id 'kotlin-android'
     id "androidx.navigation.safeargs.kotlin"
     id 'com.mikepenz.aboutlibraries.plugin'

--- a/app/src/main/java/com/klee/volumelockr/service/VolumeProvider.kt
+++ b/app/src/main/java/com/klee/volumelockr/service/VolumeProvider.kt
@@ -7,6 +7,13 @@ import com.klee.volumelockr.ui.Volume
 
 class VolumeProvider(private val mContext: Context) {
 
+    companion object {
+        const val MIN_MUSIC_VOLUME = 0
+        const val MIN_CALL_VOLUME = 1
+        const val MIN_NOTIFICATION_VOLUME = 0
+        const val MIN_ALARM_VOLUME = 1
+    }
+
     private val mAudioManager = mContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
     fun getVolumes(): List<Volume> {
@@ -16,7 +23,7 @@ class VolumeProvider(private val mContext: Context) {
                 resource.getString(R.string.media_title),
                 AudioManager.STREAM_MUSIC,
                 fetchVolume(AudioManager.STREAM_MUSIC),
-                0,
+                MIN_MUSIC_VOLUME,
                 fetchMaxVolume(AudioManager.STREAM_MUSIC),
                 false
             ),
@@ -25,7 +32,7 @@ class VolumeProvider(private val mContext: Context) {
                 resource.getString(R.string.call_title),
                 AudioManager.STREAM_VOICE_CALL,
                 fetchVolume(AudioManager.STREAM_VOICE_CALL),
-                1,
+                MIN_CALL_VOLUME,
                 fetchMaxVolume(AudioManager.STREAM_VOICE_CALL),
                 false
             ),
@@ -34,7 +41,7 @@ class VolumeProvider(private val mContext: Context) {
                 resource.getString(R.string.notification_title),
                 AudioManager.STREAM_NOTIFICATION,
                 fetchVolume(AudioManager.STREAM_NOTIFICATION),
-                0,
+                MIN_NOTIFICATION_VOLUME,
                 fetchMaxVolume(AudioManager.STREAM_NOTIFICATION),
                 false
             ),
@@ -43,7 +50,7 @@ class VolumeProvider(private val mContext: Context) {
                 resource.getString(R.string.alarm_title),
                 AudioManager.STREAM_ALARM,
                 fetchVolume(AudioManager.STREAM_ALARM),
-                1,
+                MIN_ALARM_VOLUME,
                 fetchMaxVolume(AudioManager.STREAM_ALARM),
                 false
             )
@@ -54,7 +61,7 @@ class VolumeProvider(private val mContext: Context) {
         return mAudioManager.getStreamVolume(volume)
     }
 
-    private fun fetchMaxVolume(volume: Int): Int {
+    fun fetchMaxVolume(volume: Int): Int {
         return mAudioManager.getStreamMaxVolume(volume)
     }
 }

--- a/app/src/main/java/com/klee/volumelockr/service/VolumeService.kt
+++ b/app/src/main/java/com/klee/volumelockr/service/VolumeService.kt
@@ -29,8 +29,6 @@ import com.klee.volumelockr.ui.SettingsFragment.Companion.ALLOW_LOWER_PREFERENCE
 import com.klee.volumelockr.ui.Volume
 import java.util.Timer
 import java.util.TimerTask
-import kotlin.math.max
-
 class VolumeService() : Service() {
 
     companion object {

--- a/app/src/main/java/com/klee/volumelockr/service/VolumeService.kt
+++ b/app/src/main/java/com/klee/volumelockr/service/VolumeService.kt
@@ -113,9 +113,50 @@ class VolumeService() : Service() {
     fun getVolumesPresets(): List<Volume> {
         val volumes = mVolumeProvider.getVolumes()
         volumes.forEach { volume ->
-            volume.value = mVolumePreset[volume.stream] ?: 0
+            volume.value = mVolumePreset[volume.stream] ?: getSavedVolumePreset(volume.stream)
         }
         return volumes
+    }
+
+    private fun getSavedVolumePreset(stream: Int): Int {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+
+        when (stream) {
+            AudioManager.STREAM_MUSIC -> return sharedPreferences.getInt(
+                SettingsFragment.MEDIA_VOLUME_PRESET_PREFERENCE,
+                VolumeProvider.MIN_MUSIC_VOLUME
+            ).coerceIn(
+                VolumeProvider.MIN_MUSIC_VOLUME,
+                mVolumeProvider.fetchMaxVolume(AudioManager.STREAM_MUSIC)
+            )
+
+            AudioManager.STREAM_VOICE_CALL -> return sharedPreferences.getInt(
+                SettingsFragment.CALL_VOLUME_PRESET_PREFERENCE,
+                VolumeProvider.MIN_CALL_VOLUME
+            ).coerceIn(
+                VolumeProvider.MIN_CALL_VOLUME,
+                mVolumeProvider.fetchMaxVolume(AudioManager.STREAM_VOICE_CALL)
+            )
+
+            AudioManager.STREAM_NOTIFICATION -> return sharedPreferences.getInt(
+                SettingsFragment.NOTIFICATION_VOLUME_PRESET_PREFERENCE,
+                VolumeProvider.MIN_NOTIFICATION_VOLUME
+            ).coerceIn(
+                VolumeProvider.MIN_NOTIFICATION_VOLUME, mVolumeProvider.fetchMaxVolume(
+                    AudioManager.STREAM_NOTIFICATION
+                )
+            )
+
+            AudioManager.STREAM_ALARM -> return sharedPreferences.getInt(
+                SettingsFragment.ALARM_VOLUME_PRESET_PREFERENCE,
+                VolumeProvider.MIN_ALARM_VOLUME
+            ).coerceIn(
+                VolumeProvider.MIN_ALARM_VOLUME,
+                mVolumeProvider.fetchMaxVolume(AudioManager.STREAM_ALARM)
+            )
+
+            else -> return  1
+        }
     }
 
     @Synchronized

--- a/app/src/main/java/com/klee/volumelockr/service/VolumeService.kt
+++ b/app/src/main/java/com/klee/volumelockr/service/VolumeService.kt
@@ -24,12 +24,14 @@ import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.klee.volumelockr.R
 import com.klee.volumelockr.ui.MainActivity
+import com.klee.volumelockr.ui.SettingsFragment
 import com.klee.volumelockr.ui.SettingsFragment.Companion.ALLOW_LOWER_PREFERENCE
 import com.klee.volumelockr.ui.Volume
 import java.util.Timer
 import java.util.TimerTask
+import kotlin.math.max
 
-class VolumeService : Service() {
+class VolumeService() : Service() {
 
     companion object {
         const val NOTIFICATION_TITLE = "VolumeLockr"
@@ -77,12 +79,13 @@ class VolumeService : Service() {
     private var mAllowLower = false
     private var mAllowLowerListener: (() -> Unit)? = null
 
+    private var mVolumePreset: HashMap<Int, Int> = hashMapOf<Int, Int>()
+
     override fun onCreate() {
         super.onCreate()
 
         mAudioManager = getSystemService(AUDIO_SERVICE) as AudioManager
         mVolumeProvider = VolumeProvider(this)
-
         loadPreferences()
 
         registerObservers()
@@ -109,6 +112,13 @@ class VolumeService : Service() {
     }
 
     fun getVolumes(): List<Volume> = mVolumeProvider.getVolumes()
+    fun getVolumesPresets(): List<Volume> {
+        val volumes = mVolumeProvider.getVolumes()
+        volumes.forEach { volume ->
+            volume.value = mVolumePreset[volume.stream] ?: 0
+        }
+        return volumes
+    }
 
     @Synchronized
     fun startLocking() {
@@ -152,9 +162,62 @@ class VolumeService : Service() {
     }
 
     @Synchronized
-    fun addLock(stream: Int, volume: Int) {
-        mVolumeLock[stream] = volume
+    fun addLock(stream: Int, volume: Int, fromLockAll: Boolean) {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+        val usePresetsOnLockAll =
+            sharedPreferences.getBoolean(SettingsFragment.USE_PRESETS_ALL_PREFERENCE, false)
+        val usePresetsOnLockSingle =
+            sharedPreferences.getBoolean(SettingsFragment.USE_PRESETS_INDIVIDUAL_PREFERENCE, false)
+        var presetVolumeLevel: Int
+        if (usePresetsOnLockAll || usePresetsOnLockSingle) {
+            if ((usePresetsOnLockAll && fromLockAll) || (usePresetsOnLockSingle && !fromLockAll)) {
+                presetVolumeLevel = getPresetVolumeForLockedStream(stream)
+            } else presetVolumeLevel = -1
+        } else presetVolumeLevel = -1
+
+        mVolumeLock[stream] = if (presetVolumeLevel >= 0) presetVolumeLevel else volume
         savePreferences()
+    }
+
+    fun getPresetVolumeForLockedStream(stream: Int): Int {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+
+        when (stream) {
+            AudioManager.STREAM_MUSIC -> return sharedPreferences.getInt(
+                SettingsFragment.MEDIA_VOLUME_PRESET_PREFERENCE,
+                VolumeProvider.MIN_MUSIC_VOLUME
+            ).coerceIn(
+                VolumeProvider.MIN_MUSIC_VOLUME,
+                mVolumeProvider.fetchMaxVolume(AudioManager.STREAM_MUSIC)
+            )
+
+            AudioManager.STREAM_VOICE_CALL -> return sharedPreferences.getInt(
+                SettingsFragment.CALL_VOLUME_PRESET_PREFERENCE,
+                VolumeProvider.MIN_CALL_VOLUME
+            ).coerceIn(
+                VolumeProvider.MIN_CALL_VOLUME,
+                mVolumeProvider.fetchMaxVolume(AudioManager.STREAM_VOICE_CALL)
+            )
+
+            AudioManager.STREAM_NOTIFICATION -> return sharedPreferences.getInt(
+                SettingsFragment.NOTIFICATION_VOLUME_PRESET_PREFERENCE,
+                VolumeProvider.MIN_NOTIFICATION_VOLUME
+            ).coerceIn(
+                VolumeProvider.MIN_NOTIFICATION_VOLUME, mVolumeProvider.fetchMaxVolume(
+                    AudioManager.STREAM_NOTIFICATION
+                )
+            )
+
+            AudioManager.STREAM_ALARM -> return sharedPreferences.getInt(
+                SettingsFragment.ALARM_VOLUME_PRESET_PREFERENCE,
+                VolumeProvider.MIN_ALARM_VOLUME
+            ).coerceIn(
+                VolumeProvider.MIN_ALARM_VOLUME,
+                mVolumeProvider.fetchMaxVolume(AudioManager.STREAM_ALARM)
+            )
+
+            else -> return 1
+        }
     }
 
     @Synchronized
@@ -181,7 +244,9 @@ class VolumeService : Service() {
 
     private fun loadPreferences() {
         val sharedPreferences = getSharedPreferences(APP_SHARED_PREFERENCES, MODE_PRIVATE)
+
         class Token : TypeToken<HashMap<Int, Int>>()
+
         val value = sharedPreferences.getString(LOCKS_KEY, "")
         if (value.isNullOrBlank()) {
             return
@@ -329,6 +394,10 @@ class VolumeService : Service() {
 
     private fun isForegroundStartRestriction(error: IllegalStateException): Boolean {
         return error.javaClass.name == "android.app.ForegroundServiceStartNotAllowedException"
+    }
+
+    fun setVolumePreset(stream: Int, volume: Int) {
+        mVolumePreset[stream] = volume
     }
 
     inner class LocalBinder : Binder() {

--- a/app/src/main/java/com/klee/volumelockr/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/SettingsFragment.kt
@@ -320,8 +320,4 @@ class ChangePresetDialog : DialogFragment() {
 
         return dialog
     }
-
-    fun getVolumes(): List<Volume> {
-        return volumes;
-    }
 }

--- a/app/src/main/java/com/klee/volumelockr/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/SettingsFragment.kt
@@ -1,7 +1,9 @@
 package com.klee.volumelockr.ui
 
+import android.app.Dialog
 import android.content.Context
 import android.content.SharedPreferences
+import android.media.AudioManager
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -9,6 +11,8 @@ import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.Toast
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreferenceCompat
@@ -20,6 +24,8 @@ import com.klee.volumelockr.R
 import com.klee.volumelockr.service.VolumeService
 import java.io.IOException
 import java.security.GeneralSecurityException
+import androidx.core.content.edit
+import androidx.core.os.BundleCompat
 
 class SettingsFragment : PreferenceFragmentCompat() {
 
@@ -31,6 +37,16 @@ class SettingsFragment : PreferenceFragmentCompat() {
         const val DELAY_IN_MS = 100L
         const val MIN_PASSWORD_LENGTH = 6
         private const val ENCRYPTED_PREFS_FILE = "secure_settings"
+
+        const val USE_PRESETS_ALL_PREFERENCE = "use_presets_locking_all"
+        const val USE_PRESETS_INDIVIDUAL_PREFERENCE = "use_presets_locking_individual"
+
+        const val CHANGE_PRESETS_PREFERENCE = "change_presets"
+
+        const val MEDIA_VOLUME_PRESET_PREFERENCE = "media_volume_preset"
+        const val CALL_VOLUME_PRESET_PREFERENCE = "call_volume_preset"
+        const val ALARM_VOLUME_PRESET_PREFERENCE = "alarm_volume_preset"
+        const val NOTIFICATION_VOLUME_PRESET_PREFERENCE = "notification_volume_preset"
     }
 
     private var encryptedPrefs: SharedPreferences? = null
@@ -39,6 +55,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private lateinit var passwordChange: Preference
     private lateinit var shouldAllowLower: SwitchPreferenceCompat
 
+    private lateinit var usePresetsWhenLockingAll: Preference
+    private lateinit var changePresets: Preference
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.root_preferences, rootKey)
         initializeEncryptedPrefs()
@@ -46,6 +65,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
         shouldAllowLower = findPreference(ALLOW_LOWER_PREFERENCE)!!
         passwordChange = findPreference(PASSWORD_CHANGE_PREFERENCE)!!
         passwordProtected = findPreference(PASSWORD_PROTECTED_PREFERENCE)!!
+        usePresetsWhenLockingAll = findPreference(USE_PRESETS_ALL_PREFERENCE)!!
+        changePresets = findPreference(CHANGE_PRESETS_PREFERENCE)!!
+
 
         shouldAllowLower.setOnPreferenceChangeListener { preferences, _ ->
             VolumeService.start(preferences.context)
@@ -67,6 +89,12 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
         passwordProtected.isEnabled = isPasswordSet()
+
+        changePresets.setOnPreferenceClickListener {
+            showChangePresetLevelsDialog()
+            true
+        }
+
     }
 
     private fun initializeEncryptedPrefs() {
@@ -125,6 +153,58 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
 
         dialog.show()
+    }
+
+    private fun showChangePresetLevelsDialog() {
+        val dialog = ChangePresetDialog()
+
+
+        parentFragmentManager.setFragmentResultListener(
+            "volumes",
+            viewLifecycleOwner
+        ) { _, bundle ->
+
+            val volumes = BundleCompat.getParcelableArrayList(
+                bundle,
+                "volumes",
+                Volume::class.java
+            ) ?: emptyList()
+
+            volumes.forEach {
+                when (it.stream) {
+                    AudioManager.STREAM_MUSIC ->
+                        preferenceManager.sharedPreferences?.edit {
+                            putInt(
+                                MEDIA_VOLUME_PRESET_PREFERENCE,
+                                it.value.coerceIn(it.min, it.max)
+                            )
+                        }
+
+                    AudioManager.STREAM_VOICE_CALL ->
+                        preferenceManager.sharedPreferences?.edit {
+                            putInt(CALL_VOLUME_PRESET_PREFERENCE, it.value.coerceIn(it.min, it.max))
+                        }
+
+                    AudioManager.STREAM_NOTIFICATION ->
+                        preferenceManager.sharedPreferences?.edit {
+                            putInt(
+                                NOTIFICATION_VOLUME_PRESET_PREFERENCE,
+                                it.value.coerceIn(it.min, it.max)
+                            )
+                        }
+
+                    AudioManager.STREAM_ALARM ->
+                        preferenceManager.sharedPreferences?.edit {
+                            putInt(
+                                ALARM_VOLUME_PRESET_PREFERENCE,
+                                it.value.coerceIn(it.min, it.max)
+                            )
+                        }
+                }
+            }
+        }
+        dialog.show(parentFragmentManager, "ChangePresetDialog")
+
     }
 
     private fun validatePassword(password: String): String? {
@@ -196,5 +276,52 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private fun isPasswordSet(): Boolean {
         return getStoredPassword().isNotEmpty()
+    }
+}
+
+class ChangePresetDialog : DialogFragment() {
+
+    private var volumes: List<Volume> = emptyList()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+
+
+        val view = layoutInflater.inflate(R.layout.dialog_presets, null)
+
+        val dialog = MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.change_presets)
+            .setView(view)
+            .setNegativeButton(android.R.string.cancel, null)
+            .setPositiveButton(android.R.string.ok, null)
+            .create()
+
+
+        dialog.setOnShowListener {
+            val fragment = VolumeSliderFragment().apply {
+                arguments = bundleOf(
+                    "inPreferenceMode" to true
+                )
+            }
+
+            childFragmentManager.beginTransaction()
+                .replace(R.id.volumeSliderFragment, fragment)
+                .commit()
+
+            dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                volumes = fragment.getVolumePresets()
+                parentFragmentManager.setFragmentResult(
+                    "volumes",
+                    bundleOf("volumes" to ArrayList(volumes))
+                )
+
+                dismiss()
+            }
+        }
+
+        return dialog
+    }
+
+    fun getVolumes(): List<Volume> {
+        return volumes;
     }
 }

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
@@ -95,14 +95,17 @@ class VolumeAdapter(
 
         loadLockFromService(holder, volume)
 
-        handleRingerMode(holder, volume)
         if (mInPreferencesMode) {
             holder.binding.lockButton.isEnabled = false
             holder.binding.lockButton.isVisible = false
 
-        } else if (isPasswordProtected()) {
-            holder.binding.slider.isEnabled = false
-            holder.binding.lockButton.isEnabled = false
+        }else {
+            handleRingerMode(holder, volume)
+
+            if (isPasswordProtected()) {
+                holder.binding.slider.isEnabled = false
+                holder.binding.lockButton.isEnabled = false
+            }
         }
     }
 

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
@@ -16,7 +16,6 @@ import com.google.android.material.slider.Slider
 import com.klee.volumelockr.R
 import com.klee.volumelockr.databinding.VolumeCardBinding
 import com.klee.volumelockr.service.VolumeService
-import kotlin.math.max
 import com.google.android.material.R as MaterialR
 
 class VolumeAdapter(
@@ -151,7 +150,7 @@ class VolumeAdapter(
             if (isLocked) {
                 onVolumeUnlocked(holder, volume)
             } else {
-                onVolumeLocked(holder, volume, false)
+                onVolumeLocked(holder, volume)
             }
         }
     }
@@ -204,7 +203,7 @@ class VolumeAdapter(
         }
     }
 
-    private fun onVolumeLocked(holder: ViewHolder, volume: Volume, fromLockAll: Boolean) {
+    private fun onVolumeLocked(holder: ViewHolder, volume: Volume) {
 
         mService?.let {
             it.addLock(volume.stream, volume.value, false)

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
@@ -132,7 +132,7 @@ class VolumeAdapter(
             })
         holder.binding.slider.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
             override fun onStartTrackingTouch(slider: Slider) {
-                // user started dragging
+                // user started dragging the slider, do nothing
             }
 
             override fun onStopTrackingTouch(slider: Slider) {

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.MainThread
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.color.MaterialColors
@@ -15,15 +16,16 @@ import com.google.android.material.slider.Slider
 import com.klee.volumelockr.R
 import com.klee.volumelockr.databinding.VolumeCardBinding
 import com.klee.volumelockr.service.VolumeService
+import kotlin.math.max
 import com.google.android.material.R as MaterialR
 
 class VolumeAdapter(
     private var mVolumeList: List<Volume>,
     private var mService: VolumeService?,
     private var mContext: Context,
-    var onLockStateChanged: (() -> Unit)? = null
-) :
-    RecyclerView.Adapter<VolumeAdapter.ViewHolder>() {
+    var onLockStateChanged: (() -> Unit)? = null,
+    private val mInPreferencesMode: Boolean = false
+) : RecyclerView.Adapter<VolumeAdapter.ViewHolder>() {
 
     companion object {
         private val STREAM_ICONS = mapOf(
@@ -72,12 +74,20 @@ class VolumeAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val volume = mVolumeList[position]
         holder.binding.mediaTextView.text = volume.name
-        holder.binding.streamIcon.setImageResource(STREAM_ICONS[volume.stream] ?: R.drawable.ic_media)
+        holder.binding.streamIcon.setImageResource(
+            STREAM_ICONS[volume.stream] ?: R.drawable.ic_media
+        )
         applyStreamColors(holder, volume.stream)
-        holder.binding.slider.value = mService?.getLocks()?.get(volume.stream)?.toFloat() ?: volume.value.toFloat()
+        if (mInPreferencesMode) {
+            holder.binding.slider.value = getVolumePresetLevel(volume).toFloat()
+        } else {
+            holder.binding.slider.value =
+                mService?.getLocks()?.get(volume.stream)?.toFloat() ?: volume.value.toFloat()
+        }
         holder.binding.slider.valueFrom = volume.min.toFloat()
         holder.binding.slider.valueTo = volume.max.toFloat()
-        holder.binding.volumeValue.text = formatVolumeValue(holder.binding.slider.value.toInt(), volume.max)
+        holder.binding.volumeValue.text =
+            formatVolumeValue(holder.binding.slider.value.toInt(), volume.max)
 
         registerSeekBarCallback(holder, volume)
         registerLockButtonCallback(holder, volume)
@@ -85,8 +95,11 @@ class VolumeAdapter(
         loadLockFromService(holder, volume)
 
         handleRingerMode(holder, volume)
+        if (mInPreferencesMode) {
+            holder.binding.lockButton.isEnabled = false
+            holder.binding.lockButton.isVisible = false
 
-        if (isPasswordProtected()) {
+        } else if (isPasswordProtected()) {
             holder.binding.slider.isEnabled = false
             holder.binding.lockButton.isEnabled = false
         }
@@ -94,7 +107,8 @@ class VolumeAdapter(
 
     private fun applyStreamColors(holder: ViewHolder, stream: Int) {
         val containerAttr = STREAM_CONTAINER_COLORS[stream] ?: MaterialR.attr.colorPrimaryContainer
-        val onContainerAttr = STREAM_ON_CONTAINER_COLORS[stream] ?: MaterialR.attr.colorOnPrimaryContainer
+        val onContainerAttr =
+            STREAM_ON_CONTAINER_COLORS[stream] ?: MaterialR.attr.colorOnPrimaryContainer
         val containerColor = MaterialColors.getColor(holder.binding.root, containerAttr)
         val onContainerColor = MaterialColors.getColor(holder.binding.root, onContainerAttr)
         holder.binding.iconContainer.backgroundTintList = ColorStateList.valueOf(containerColor)
@@ -107,16 +121,28 @@ class VolumeAdapter(
         holder.binding.slider.clearOnChangeListeners()
         holder.binding.slider.addOnChangeListener(
             Slider.OnChangeListener { _, value, _ ->
-                val canSetVolume = volume.stream != AudioManager.STREAM_NOTIFICATION ||
-                    mService?.getMode() == AudioManager.RINGER_MODE_NORMAL
-                if (canSetVolume) {
-                    mAudioManager.setStreamVolume(volume.stream, value.toInt(), 0)
+                if (!mInPreferencesMode) {
+                    val canSetVolume =
+                        volume.stream != AudioManager.STREAM_NOTIFICATION || mService?.getMode() == AudioManager.RINGER_MODE_NORMAL
+                    if (canSetVolume) {
+                        mAudioManager.setStreamVolume(volume.stream, value.toInt(), 0)
+                    }
                 }
-
                 volume.value = value.toInt()
                 holder.binding.volumeValue.text = formatVolumeValue(value.toInt(), volume.max)
+            })
+        holder.binding.slider.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
+            override fun onStartTrackingTouch(slider: Slider) {
+                // user started dragging
             }
-        )
+
+            override fun onStopTrackingTouch(slider: Slider) {
+                // user released the slider
+                if (mInPreferencesMode) {
+                    mService?.setVolumePreset(volume.stream, volume.value)
+                }
+            }
+        })
     }
 
     private fun registerLockButtonCallback(holder: ViewHolder, volume: Volume) {
@@ -125,20 +151,23 @@ class VolumeAdapter(
             if (isLocked) {
                 onVolumeUnlocked(holder, volume)
             } else {
-                onVolumeLocked(holder, volume)
+                onVolumeLocked(holder, volume, false)
             }
         }
     }
 
     private fun loadLockFromService(holder: ViewHolder, volume: Volume) {
         val isLocked = mService?.getLocks()?.containsKey(volume.stream) == true
-        applyLockedState(holder, isLocked)
-        holder.binding.slider.isEnabled = !isLocked
+        if (!mInPreferencesMode) {
+            applyLockedState(holder, isLocked)
+            holder.binding.slider.isEnabled = !isLocked
+        }
     }
 
     private fun applyLockedState(holder: ViewHolder, isLocked: Boolean) {
         val iconRes = if (isLocked) R.drawable.ic_lock else R.drawable.ic_lock_open
-        val tintAttr = if (isLocked) android.R.attr.colorPrimary else MaterialR.attr.colorOnSurfaceVariant
+        val tintAttr =
+            if (isLocked) android.R.attr.colorPrimary else MaterialR.attr.colorOnSurfaceVariant
         val tintColor = MaterialColors.getColor(holder.binding.root, tintAttr)
 
         holder.binding.lockButton.icon = ContextCompat.getDrawable(mContext, iconRes)
@@ -170,14 +199,15 @@ class VolumeAdapter(
     private fun handleRingerMode(holder: ViewHolder, volume: Volume) {
         if (volume.stream == AudioManager.STREAM_NOTIFICATION) {
             holder.binding.slider.isEnabled =
-                mService?.getMode() == AudioManager.RINGER_MODE_NORMAL &&
-                mService?.getLocks()?.containsKey(AudioManager.STREAM_NOTIFICATION) == false
+                mService?.getMode() == AudioManager.RINGER_MODE_NORMAL && mService?.getLocks()
+                    ?.containsKey(AudioManager.STREAM_NOTIFICATION) == false
         }
     }
 
-    private fun onVolumeLocked(holder: ViewHolder, volume: Volume) {
+    private fun onVolumeLocked(holder: ViewHolder, volume: Volume, fromLockAll: Boolean) {
+
         mService?.let {
-            it.addLock(volume.stream, volume.value)
+            it.addLock(volume.stream, volume.value, false)
             VolumeService.start(mContext)
             adjustService()
             adjustNotification()
@@ -205,6 +235,33 @@ class VolumeAdapter(
 
     override fun getItemCount(): Int {
         return mVolumeList.size
+    }
+
+    private fun getVolumePresetLevel(volume: Volume): Int {
+        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(mContext)
+        when (volume.stream) {
+            AudioManager.STREAM_MUSIC -> return sharedPreferences.getInt(
+                SettingsFragment.MEDIA_VOLUME_PRESET_PREFERENCE,
+                volume.min
+            ).coerceIn(volume.min, volume.max)
+
+            AudioManager.STREAM_VOICE_CALL -> return sharedPreferences.getInt(
+                SettingsFragment.CALL_VOLUME_PRESET_PREFERENCE,
+                volume.min
+            ).coerceIn(volume.min, volume.max)
+
+            AudioManager.STREAM_NOTIFICATION -> return sharedPreferences.getInt(
+                SettingsFragment.NOTIFICATION_VOLUME_PRESET_PREFERENCE,
+                volume.min
+            ).coerceIn(volume.min, volume.max)
+
+            AudioManager.STREAM_ALARM -> return sharedPreferences.getInt(
+                SettingsFragment.ALARM_VOLUME_PRESET_PREFERENCE,
+                volume.min
+            ).coerceIn(volume.min, volume.max)
+
+            else -> return 1
+        }
     }
 }
 

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeAdapter.kt
@@ -17,6 +17,8 @@ import com.klee.volumelockr.R
 import com.klee.volumelockr.databinding.VolumeCardBinding
 import com.klee.volumelockr.service.VolumeService
 import com.google.android.material.R as MaterialR
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 
 class VolumeAdapter(
     private var mVolumeList: List<Volume>,
@@ -264,6 +266,7 @@ class VolumeAdapter(
     }
 }
 
+@Parcelize
 data class Volume(
     val name: String,
     val stream: Int,
@@ -271,4 +274,4 @@ data class Volume(
     val min: Int,
     val max: Int,
     var locked: Boolean
-)
+) : Parcelable

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeSliderFragment.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeSliderFragment.kt
@@ -13,11 +13,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
 import androidx.preference.PreferenceManager
 import com.klee.volumelockr.R
 import com.klee.volumelockr.databinding.FragmentVolumeSliderBinding
 import com.klee.volumelockr.service.VolumeService
+import com.klee.volumelockr.ui.VolumeSliderFragmentArgs
 
 class VolumeSliderFragment : Fragment() {
 
@@ -26,6 +29,8 @@ class VolumeSliderFragment : Fragment() {
     private var mAdapter: VolumeAdapter? = null
     private var mService: VolumeService? = null
     private var isServiceBound = false
+    private val args: VolumeSliderFragmentArgs by navArgs()
+    private var inPreferenceMode: Boolean = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -33,6 +38,8 @@ class VolumeSliderFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentVolumeSliderBinding.inflate(inflater, container, false)
+        inPreferenceMode = args.inPreferenceMode
+
         return binding.root
     }
 
@@ -43,6 +50,8 @@ class VolumeSliderFragment : Fragment() {
         } ?: Intent(context, VolumeService::class.java).also { intent ->
             context?.bindService(intent, connection, Context.BIND_AUTO_CREATE)
         }
+        inPreferenceMode = args.inPreferenceMode
+
     }
 
     override fun onPause() {
@@ -60,8 +69,15 @@ class VolumeSliderFragment : Fragment() {
 
     private fun setupRecyclerView(service: VolumeService) {
         val spanCount = if (resources.getBoolean(R.bool.use_two_columns)) 2 else 1
-        binding.recyclerView.layoutManager = androidx.recyclerview.widget.GridLayoutManager(requireContext(), spanCount)
-        mAdapter = VolumeAdapter(service.getVolumes(), service, requireContext()).also { adapter ->
+        binding.recyclerView.layoutManager =
+            androidx.recyclerview.widget.GridLayoutManager(requireContext(), spanCount)
+        mAdapter = VolumeAdapter(
+            service.getVolumes(),
+            service,
+            requireContext(),
+            null,
+            inPreferenceMode
+        ).also { adapter ->
             adapter.onLockStateChanged = { updateSubtitle() }
         }
         binding.recyclerView.adapter = mAdapter
@@ -76,7 +92,7 @@ class VolumeSliderFragment : Fragment() {
     private fun lockAll() {
         val service = mService ?: return
         service.getVolumes().forEach { volume ->
-            service.addLock(volume.stream, volume.value)
+            service.addLock(volume.stream, volume.value, true)
         }
         VolumeService.start(requireContext())
         service.startLocking()
@@ -101,10 +117,17 @@ class VolumeSliderFragment : Fragment() {
     }
 
     private fun updateQuickActionState() {
-        val isProtected = PreferenceManager.getDefaultSharedPreferences(requireContext())
-            .getBoolean(SettingsFragment.PASSWORD_PROTECTED_PREFERENCE, false)
-        binding.lockAllChip.isEnabled = !isProtected
-        binding.unlockAllChip.isEnabled = !isProtected
+        if (inPreferenceMode) {
+            binding.lockAllChip.isEnabled = false
+            binding.unlockAllChip.isEnabled = false
+            binding.lockAllChip.isVisible = false
+            binding.unlockAllChip.isVisible = false
+        } else {
+            val isProtected = PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .getBoolean(SettingsFragment.PASSWORD_PROTECTED_PREFERENCE, false)
+            binding.lockAllChip.isEnabled = !isProtected
+            binding.unlockAllChip.isEnabled = !isProtected
+        }
     }
 
     private fun updateSubtitle() {
@@ -163,5 +186,9 @@ class VolumeSliderFragment : Fragment() {
 
         mService = null
         mAdapter = null
+    }
+
+    fun getVolumePresets(): List<Volume> {
+        return mService?.getVolumesPresets() ?: emptyList()
     }
 }

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeSliderFragment.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeSliderFragment.kt
@@ -15,7 +15,6 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.navArgs
 import androidx.preference.PreferenceManager
 import com.klee.volumelockr.R
 import com.klee.volumelockr.databinding.FragmentVolumeSliderBinding
@@ -27,8 +26,8 @@ class VolumeSliderFragment : Fragment() {
     private var mAdapter: VolumeAdapter? = null
     private var mService: VolumeService? = null
     private var isServiceBound = false
-    private val args: VolumeSliderFragmentArgs by navArgs()
-    private var inPreferenceMode: Boolean = false
+    private val inPreferenceMode: Boolean
+        get() = arguments?.let { VolumeSliderFragmentArgs.fromBundle(it).inPreferenceMode } ?: false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -36,7 +35,6 @@ class VolumeSliderFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentVolumeSliderBinding.inflate(inflater, container, false)
-        inPreferenceMode = args.inPreferenceMode
 
         return binding.root
     }
@@ -48,8 +46,6 @@ class VolumeSliderFragment : Fragment() {
         } ?: Intent(context, VolumeService::class.java).also { intent ->
             context?.bindService(intent, connection, Context.BIND_AUTO_CREATE)
         }
-        inPreferenceMode = args.inPreferenceMode
-
     }
 
     override fun onPause() {
@@ -165,9 +161,11 @@ class VolumeSliderFragment : Fragment() {
             setupQuickActions()
             updateSubtitle()
 
-            mService?.registerOnVolumeChangeListener(Handler(Looper.getMainLooper())) {
-                mAdapter?.update(it.getVolumes())
-                updateSubtitle()
+            if (!inPreferenceMode) {
+                mService?.registerOnVolumeChangeListener(Handler(Looper.getMainLooper())) {
+                    mAdapter?.update(it.getVolumes())
+                    updateSubtitle()
+                }
             }
         }
     }

--- a/app/src/main/java/com/klee/volumelockr/ui/VolumeSliderFragment.kt
+++ b/app/src/main/java/com/klee/volumelockr/ui/VolumeSliderFragment.kt
@@ -20,8 +20,6 @@ import androidx.preference.PreferenceManager
 import com.klee.volumelockr.R
 import com.klee.volumelockr.databinding.FragmentVolumeSliderBinding
 import com.klee.volumelockr.service.VolumeService
-import com.klee.volumelockr.ui.VolumeSliderFragmentArgs
-
 class VolumeSliderFragment : Fragment() {
 
     private var _binding: FragmentVolumeSliderBinding? = null

--- a/app/src/main/res/layout/dialog_presets.xml
+++ b/app/src/main/res/layout/dialog_presets.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/dialog_margin"
+    android:paddingEnd="@dimen/dialog_margin">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/volumeSliderFragment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:label="@string/app_name"></androidx.fragment.app.FragmentContainerView>
+</FrameLayout>

--- a/app/src/main/res/layout/dialog_presets.xml
+++ b/app/src/main/res/layout/dialog_presets.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingStart="@dimen/dialog_margin"
@@ -10,5 +9,5 @@
         android:id="@+id/volumeSliderFragment"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:label="@string/app_name"></androidx.fragment.app.FragmentContainerView>
+        android:label="@string/app_name"/>
 </FrameLayout>

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -21,13 +21,17 @@
             android:id="@+id/action_x_to_about_libs"
             app:destination="@id/about_libraries" />
         <action
-          android:id="@+id/action_sliders_to_settings"
-          app:destination="@id/settingsFragment" />
+            android:id="@+id/action_sliders_to_settings"
+            app:destination="@id/settingsFragment" />
+        <argument
+            android:name="inPreferenceMode"
+            android:defaultValue="false"
+            app:argType="boolean" />
     </fragment>
 
     <fragment
-      android:id="@+id/settingsFragment"
-      android:name="com.klee.volumelockr.ui.SettingsFragment"
-      android:label="@string/options" />
+        android:id="@+id/settingsFragment"
+        android:name="com.klee.volumelockr.ui.SettingsFragment"
+        android:label="@string/options" />
 
 </navigation>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -23,13 +23,5 @@
     <string name="limiting_header">حدود الصوت</string>
     <string name="allow_lower">السماح بخفض مستوى الصوت</string>
 
-    <string name="lock_all">قفل الكل</string>
-    <string name="unlock_all">إلغاء قفل الكل</string>
-    <string name="locked_subtitle">%1$d من %2$d تم قفل</string>
-
-    <string name="allow_lower_summary">السماح للنظام بخفض الصوت أقل من المستوى المقفل</string>
-    <string name="password_protected_summary">يتطلب كلمة السر لتغيير إعدادات القفل</string>
-    <string name="change_password_summary">اضبط أو حدّث كلمة السر الخاصة بإلغاء القفل</string>
-    
     <string name="aboutLibraries_description_text">VolumeLockr</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
 
     <string name="preset_levels_text">Preset levels</string>
     <string name="use_presets_all">Use presets for all locks</string>
-    <string name="use_presets_all_summary">Set volume to preset levels when locking all</string>
+    <string name="use_presets_all_summary">Set volume to preset levels when locking all volumes</string>
     <string name="use_presets_individual">Use presets for individual locks</string>
     <string name="use_presets_individual_summary">Set volume to preset levels when locking individual volumes</string>
     <string name="change_presets">Change presets</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,13 @@
     <string name="change_password_summary">Set or update the unlock password</string>
 
     <string name="aboutLibraries_description_text">VolumeLockr</string>
+
+    <string name="preset_levels_text">Preset levels</string>
+    <string name="use_presets_all">Use presets for all locks</string>
+    <string name="use_presets_all_summary">Set volume to preset levels when locking all</string>
+    <string name="use_presets_individual">Use presets for individual locks</string>
+    <string name="use_presets_individual_summary">Set volume to preset levels when locking individual volumes</string>
+    <string name="change_presets">Change presets</string>
+    <string name="change_presets_summary">Set or update preset volume levels</string>
+
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,27 +1,46 @@
 <PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
-  <PreferenceCategory app:title="@string/limiting_header">
+    <PreferenceCategory app:title="@string/limiting_header">
 
-    <SwitchPreferenceCompat
-        app:key="allow_lower"
-        app:title="@string/allow_lower"
-        app:summary="@string/allow_lower_summary"
-        app:defaultValue="false" />
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="allow_lower"
+            app:summary="@string/allow_lower_summary"
+            app:title="@string/allow_lower" />
 
-  </PreferenceCategory>
+    </PreferenceCategory>
 
-  <PreferenceCategory app:title="@string/password_header">
+    <PreferenceCategory app:title="@string/password_header">
 
-    <SwitchPreferenceCompat
-        app:key="password_protected"
-        app:title="@string/password_protected"
-        app:summary="@string/password_protected_summary" />
+        <SwitchPreferenceCompat
+            app:key="password_protected"
+            app:summary="@string/password_protected_summary"
+            app:title="@string/password_protected" />
 
-    <Preference
-        app:key="password"
-        app:title="@string/change_password"
-        app:summary="@string/change_password_summary" />
+        <Preference
+            app:key="password"
+            app:summary="@string/change_password_summary"
+            app:title="@string/change_password" />
 
-  </PreferenceCategory>
+    </PreferenceCategory>
+    <PreferenceCategory app:title="@string/preset_levels_text">
+
+        <SwitchPreferenceCompat
+            app:key="use_presets_locking_all"
+            app:summary="@string/use_presets_all_summary"
+            app:title="@string/use_presets_all" />
+
+        <SwitchPreferenceCompat
+            app:key="use_presets_locking_individual"
+            app:summary="@string/use_presets_individual_summary"
+            app:title="@string/use_presets_individual" />
+
+
+        <Preference
+            app:key="change_presets"
+            app:summary="@string/change_presets_summary"
+            app:title="@string/change_presets" />
+
+    </PreferenceCategory>
 
 </PreferenceScreen>

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath libs.gradle
         classpath libs.aboutlibraries.plugin
         classpath libs.kotlin.gradle.plugin
-
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.8.9"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
Added a feature that allows the user to set pre-determined volumes for when they apply a lock. The user can choose if they want to apply the presets when they lock a single volume, lock all volumes, or both. This is my first contribution to an Android app, so feedback is welcome.

The new dialog in preferences to set the presets uses the existing VolumeFragment to lower potential burden of adding new sliders in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable preset volume levels for music, calls, notifications, and alarms.
  * Added settings to apply presets to all locks or individual locks.
  * Added a preset editor with sliders and validation for permitted volume ranges.
  * Preset values are now applied when creating volume locks and retained for future use.
* **User Interface**
  * Added preset-related settings, labels, and editing controls.
  * Lock controls are hidden while editing presets to prevent accidental locking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->